### PR TITLE
Fix some spelling mistakes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -20,8 +20,8 @@ mod rpc_wrapper {
 	tonic::include_proto!("links");
 }
 
-/// The grpc api implementation. Contains a reference to the store on which all
-/// operations are performed. Implements all rpc calls from `links.proto`.
+/// The grpc API implementation. Contains a reference to the store on which all
+/// operations are performed. Implements all RPC calls from `links.proto`.
 #[derive(Debug)]
 pub struct Api {
 	store: &'static Store,

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -15,11 +15,11 @@
 //! ## The gRPC server
 //! Links runs a gRPC server via [tonic](https://github.com/hyperium/tonic) to
 //! provide seamless access to the backend store for tasks such as setting a
-//! redirect. The server is authenticated with JWTs (TODO). The protcol
+//! redirect. The server is authenticated with JWTs (TODO). The protocol
 //! definition can be found in [`proto/links.proto`](../proto/links.proto).
 //!
 //! ## The store backend
-//! Links can use many (TODO) databases and datastores as store backends,
+//! Links can use many (TODO) databases and data stores as store backends,
 //! providing flexibility with the storage setup. Currently in-memory,
 //! in-memory with file backup (TODO), and redis (TODO) backends are supported.
 
@@ -116,7 +116,7 @@ async fn main() -> Result<(), anyhow::Error> {
 	tracing::subscriber::set_global_default(tracing_subscriber)
 		.expect("setting tracing default subscriber failed");
 
-	// Listen on all addresses, on port 80 (http)
+	// Listen on all addresses, on port 80 (HTTP)
 	let http_addr = SocketAddr::from(([0, 0, 0, 0], 80));
 	// Listen on all addresses, on port 530 (gRPC)
 	let rpc_addr = SocketAddr::from(([0, 0, 0, 0], 530));
@@ -132,12 +132,12 @@ async fn main() -> Result<(), anyhow::Error> {
 	)
 	.await?;
 
-	// Create the rpc service
+	// Create the gRPC service
 	let rpc_service = Api::new(store);
 
-	// Start the rpc api server
+	// Start the gRPC API server
 	let rpc_handle = spawn(async move {
-		// Start the rpc server
+		// Start the gRPC server
 		let rpc_server = RpcServer::builder()
 			.add_service(LinksServer::new(rpc_service).send_gzip().accept_gzip())
 			.serve(rpc_addr);
@@ -148,7 +148,7 @@ async fn main() -> Result<(), anyhow::Error> {
 		}
 	});
 
-	// Start the http server
+	// Start the HTTP server
 	let tcp_listener = TcpListener::bind(http_addr).await?;
 	let http_handle = spawn(async move {
 		loop {

--- a/src/id.rs
+++ b/src/id.rs
@@ -43,7 +43,7 @@ pub const REVERSE_CHARSET: [u8; 69] = [
 	30, 0, 31, 32, 33, 0, 34, 0, 0, 35, 36, 0, 37,
 ];
 
-/// The offset from the ascii value of a base 38 character to its index in
+/// The offset from the ASCII value of a base 38 character to its index in
 /// `REVERSE_CHARSET`. To get the index of a character in `REVERSE_CHARSET`,
 /// subtract `REVERSE_CHARSET_BASE_38_OFFSET` from its value (`ascii - this`).
 pub const REVERSE_CHARSET_BASE_38_OFFSET: usize = 54;
@@ -95,7 +95,7 @@ impl Id {
 		Self(rand::random())
 	}
 
-	/// Convert this Id into a u64.
+	/// Convert this `Id` into a `u64`.
 	#[must_use]
 	pub fn to_u64(self) -> u64 {
 		let mut buf = [0u8; 8];

--- a/src/normalized.rs
+++ b/src/normalized.rs
@@ -75,7 +75,7 @@ pub enum LinkError {
 }
 
 /// A normalized URL used as the redirect destination. This ensures that the
-/// link is a valid absolute http(s) URL. The resulting `Link` is guaranteed to
+/// link is a valid absolute HTTP(S) URL. The resulting `Link` is guaranteed to
 /// have an `http` or `https` scheme, be an absolute URL, not have a password,
 /// and be properly percent encoded. Note that this doesn't aim to make invalid
 /// URLs valid (e.g. by percent encoding non-ascii characters), but may

--- a/src/redirector.rs
+++ b/src/redirector.rs
@@ -40,7 +40,7 @@ impl Default for Config {
 	}
 }
 
-/// Redirects the `req`uest to the appropriate target url (if one is found in
+/// Redirects the `req`uest to the appropriate target URL (if one is found in
 /// the `store`) or returns a `404 Not Found` response. When redirecting, the
 /// status code is `302 Found` when the method is GET, and `307 Temporary
 /// Redirect` otherwise.

--- a/src/store/backend.rs
+++ b/src/store/backend.rs
@@ -51,9 +51,9 @@ pub trait StoreBackend: Debug + Send + Sync {
 	/// changed to the new one, returning the old one.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely set / processed /
+	/// If an `Ok` is returned, the new value was definitely set / processed /
 	/// saved, and will be available on next request.
-	/// If an Err is returned, the value must not have been set / modified,
+	/// If an `Err` is returned, the value must not have been set / modified,
 	/// insofar as that is possible to determine from the backend.
 	async fn set_redirect(&self, from: Id, to: Link) -> Result<Option<Link>>;
 
@@ -62,10 +62,10 @@ pub trait StoreBackend: Debug + Send + Sync {
 	/// mapping.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely removed / processed
-	/// / saved, and will be unavailable on next request.
-	/// If an Err is returned, the value must not have been removed / modified,
-	/// insofar as that is possible to determine from the backend.
+	/// If an `Ok` is returned, the new value was definitely removed /
+	/// processed / saved, and will be unavailable on next request.
+	/// If an `Err` is returned, the value must not have been removed /
+	/// modified, insofar as that is possible to determine from the backend.
 	async fn rem_redirect(&self, from: Id) -> Result<Option<Link>>;
 
 	/// Get a vanity path's ID. Returns the ID of the `to` link corresponding
@@ -83,9 +83,9 @@ pub trait StoreBackend: Debug + Send + Sync {
 	/// exists, it must be changed to the new one, returning the old one.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely set / processed /
+	/// If an `Ok` is returned, the new value was definitely set / processed /
 	/// saved, and will be available on next request.
-	/// If an Err is returned, the value must not have been set / modified,
+	/// If an `Err` is returned, the value must not have been set / modified,
 	/// insofar as that is possible to determine from the backend.
 	async fn set_vanity(&self, from: Normalized, to: Id) -> Result<Option<Id>>;
 
@@ -93,9 +93,9 @@ pub trait StoreBackend: Debug + Send + Sync {
 	/// the old value of the mapping or `None` if there was no such mapping.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely removed / processed
-	/// / saved, and will be unavailable on next request.
-	/// If an Err is returned, the value must not have been removed / modified,
-	/// insofar as that is possible to determine from the backend.
+	/// If an `Ok` is returned, the new value was definitely removed /
+	/// processed / saved, and will be unavailable on next request.
+	/// If an `Err` is returned, the value must not have been removed /
+	/// modified, insofar as that is possible to determine from the backend.
 	async fn rem_vanity(&self, from: Normalized) -> Result<Option<Id>>;
 }

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -22,7 +22,7 @@ use std::sync::RwLock;
 use tracing::instrument;
 
 /// A fully in-memory `StoreBackend` implementation useful for testing. Not
-/// recommended for production, as this lacks any data persistance or backups.
+/// recommended for production, as this lacks any data persistence or backups.
 #[derive(Debug)]
 pub struct Store {
 	redirects: RwLock<HashMap<Id, Link>>,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -85,9 +85,9 @@ impl Store {
 	/// changed to the new one, returning the old one.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely set / processed /
+	/// If an `Ok` is returned, the new value was definitely set / processed /
 	/// saved, and will be available on next request.
-	/// If an Err is returned, the value must not have been set / modified,
+	/// If an `Err` is returned, the value must not have been set / modified,
 	/// insofar as that is possible to determine from the backend.
 	#[instrument(level = "debug", skip(self), fields(name = self.backend_name()), ret, err)]
 	pub async fn set_redirect(&self, from: Id, to: Link) -> Result<Option<Link>> {
@@ -99,10 +99,10 @@ impl Store {
 	/// mapping.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely removed / processed
-	/// / saved, and will be unavailable on next request.
-	/// If an Err is returned, the value must not have been removed / modified,
-	/// insofar as that is possible to determine from the backend.
+	/// If an `Ok` is returned, the new value was definitely removed /
+	/// processed / saved, and will be unavailable on next request.
+	/// If an `Err` is returned, the value must not have been removed /
+	/// modified, insofar as that is possible to determine from the backend.
 	#[instrument(level = "debug", skip(self), fields(name = self.backend_name()), ret, err)]
 	pub async fn rem_redirect(&self, from: Id) -> Result<Option<Link>> {
 		self.store.rem_redirect(from).await
@@ -126,9 +126,9 @@ impl Store {
 	/// exists, it must be changed to the new one, returning the old one.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely set / processed /
+	/// If an `Ok` is returned, the new value was definitely set / processed /
 	/// saved, and will be available on next request.
-	/// If an Err is returned, the value must not have been set / modified,
+	/// If an `Err` is returned, the value must not have been set / modified,
 	/// insofar as that is possible to determine from the backend.
 	#[instrument(level = "debug", skip(self), fields(name = self.backend_name()), ret, err)]
 	pub async fn set_vanity(&self, from: Normalized, to: Id) -> Result<Option<Id>> {
@@ -139,10 +139,10 @@ impl Store {
 	/// the old value of the mapping or `None` if there was no such mapping.
 	///
 	/// # Storage Guarantees
-	/// If an Ok is returned, the new value was definitely removed / processed
-	/// / saved, and will be unavailable on next request.
-	/// If an Err is returned, the value must not have been removed / modified,
-	/// insofar as that is possible to determine from the backend.
+	/// If an `Ok` is returned, the new value was definitely removed /
+	/// processed / saved, and will be unavailable on next request.
+	/// If an `Err` is returned, the value must not have been removed /
+	/// modified, insofar as that is possible to determine from the backend.
 	#[instrument(level = "debug", skip(self), fields(name = self.backend_name()), ret, err)]
 	pub async fn rem_vanity(&self, from: Normalized) -> Result<Option<Id>> {
 		self.store.rem_vanity(from).await

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,9 +12,9 @@ lazy_static! {
 		env!("CARGO_PKG_VERSION_MAJOR").to_string() + "." + env!("CARGO_PKG_VERSION_MINOR")
 	};
 
-	/// The name of the http(s) server implemented by this crate. Used in e.g.
-	/// the `Server` http header. Currently this is `hyperlinks/[version]`,
-	/// where `hyper` refers to the http library used, `links` is this crate's
+	/// The name of the HTTP(S) server implemented by this crate. Used in e.g.
+	/// the `Server` HTTP header. Currently this is `hyperlinks/[version]`,
+	/// where `hyper` refers to the HTTP library used, `links` is this crate's
 	/// name, and the version is `util::VERSION`.
 	pub static ref SERVER_NAME: String = format!("hyperlinks/{}", &*VERSION);
 }


### PR DESCRIPTION
Fix some minor spelling mistakes in the documentation and comments.
Waiting for `feature-tls` to be merged before merging this.